### PR TITLE
docs: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Something is broken
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## 🐛 Problem
+- 
+
+## 🔁 Steps to reproduce
+1. 
+2. 
+3. 
+
+## 🎯 Expected
+- 
+
+## ❌ Actual
+- 
+
+## 🖥 Environment
+- OS:
+- Browser:
+- Version:
+
+## ✅ Fix criteria
+- [ ] Reproduced
+- [ ] Fixed
+- [ ] Tested

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -19,5 +19,5 @@ assignees: ""
 - 
 
 ## ✅ Acceptance criteria
-- [ ] 
-- [ ] 
+- [ ] Acceptance criterion 1 (clear, testable outcome)
+- [ ] Acceptance criterion 2 (clear, testable outcome)

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+---
+name: Feature
+about: New feature request
+title: "[FEAT] "
+labels: feature
+assignees: ""
+---
+
+## ✨ Feature
+- 
+
+## 🎯 Goal
+- 
+
+## 💡 Proposal
+- 
+
+## 🔄 Alternatives considered
+- 
+
+## ✅ Acceptance criteria
+- [ ] 
+- [ ] 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -33,4 +33,4 @@ assignees: ""
 
 ## 🔗 Related
 <!-- Links: PR / issue / doc -->
--
+- 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,36 @@
+---
+name: Task
+about: General development task
+title: "[TASK] "
+labels: task
+assignees: ""
+---
+
+## 📌 What
+<!-- What needs to be done -->
+- 
+
+## 🎯 Why
+<!-- Why is this necessary? Background / problem -->
+- 
+
+## 🧱 Scope
+<!-- What is included / excluded -->
+### Included
+- 
+
+### Not included
+- 
+
+## 🛠 Approach
+<!-- Rough implementation plan -->
+- 
+
+## ✅ Done criteria
+- [ ] 
+- [ ] 
+- [ ] 
+
+## 🔗 Related
+<!-- Links: PR / issue / doc -->
+-


### PR DESCRIPTION
## Summary
- Add three GitHub issue templates: bug report, feature request, and general task
- Each template includes YAML front matter for automatic label and title prefix
- Standardizes issue creation across the project

Closes #3

## Test plan
- [ ] Verify templates appear in GitHub issue creation UI
- [ ] Confirm each template renders correctly with proper labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)