### PR TITLE
docs: add OpenAPI specification for Visitor & Analytics API

### DIFF
--- a/contracts/openapi/visitor.yaml
+++ b/contracts/openapi/visitor.yaml
@@ -1,0 +1,553 @@
+openapi: 3.1.0
+info:
+  title: Blog Visitor & Analytics API
+  description: |
+    Visitor tracking, Google Analytics, health-check, and full-text search
+    indexing APIs for the blog platform.
+  version: 0.1.0
+  license:
+    name: MIT
+    identifier: MIT
+
+servers:
+  - url: https://mogumogu.dev
+    description: Production
+
+tags:
+  - name: visitor
+    description: Visitor fingerprint tracking
+  - name: analytics
+    description: Google Analytics data retrieval
+  - name: status
+    description: Health check and API quota status
+  - name: indexing
+    description: Full-text search indexing (Fuse.js)
+
+paths:
+  /api/visitor:
+    post:
+      operationId: recordVisitor
+      summary: Record a visitor
+      description: |
+        Upserts a visitor fingerprint record. On first visit, inserts a new row
+        with bot detection and geolocation data extracted from request headers
+        (Cloudflare `cf-connecting-ip`, `cf-ipcountry`). On subsequent visits,
+        increments `visit_count` and updates `last_visited`, `ip_address`,
+        `country`, and `is_bot`.
+      tags:
+        - visitor
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecordVisitorRequest"
+            example:
+              fingerprint: abc123def456
+      responses:
+        "200":
+          description: Visitor recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OkResponse"
+              example:
+                ok: true
+        "400":
+          description: Missing fingerprint in request body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Fingerprint is required
+
+  /api/visitor/{fingerprint}:
+    parameters:
+      - $ref: "#/components/parameters/Fingerprint"
+
+    get:
+      operationId: getVisitor
+      summary: Get visitor info by fingerprint
+      description: |
+        Looks up a visitor record by fingerprint. Returns the full visitor
+        record if found, or `found: false` if no matching fingerprint exists.
+        Both cases return HTTP 200.
+      tags:
+        - visitor
+      security: []
+      responses:
+        "200":
+          description: Visitor lookup result
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/VisitorFound"
+                  - $ref: "#/components/schemas/VisitorNotFound"
+              examples:
+                found:
+                  summary: Visitor exists
+                  value:
+                    ok: true
+                    found: true
+                    data:
+                      id: 550e8400-e29b-41d4-a716-446655440000
+                      fingerprint: abc123def456
+                      user_agent: "Mozilla/5.0 ..."
+                      ip_address: 203.0.113.42
+                      country: KR
+                      is_bot: false
+                      first_visited: "2025-06-01T09:00:00.000Z"
+                      last_visited: "2025-06-15T14:30:00.000Z"
+                      visit_count: 12
+                notFound:
+                  summary: No matching visitor
+                  value:
+                    ok: false
+                    found: false
+        "400":
+          description: Missing fingerprint parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Fingerprint is required
+
+  /api/google/analytics:
+    get:
+      operationId: getAnalytics
+      summary: Get Google Analytics data
+      description: |
+        Fetches active-user analytics from the Google Analytics Data API
+        (GA4) for the last 7 days, grouped by date. Requires a valid
+        `GA4_PROPERTY_ID` environment variable and Google service-account
+        credentials on the server.
+      tags:
+        - analytics
+      security: []
+      responses:
+        "200":
+          description: Analytics data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnalyticsResponse"
+              example:
+                data:
+                  - date: "20250601"
+                    activeUsers: "142"
+                  - date: "20250602"
+                    activeUsers: "158"
+        "500":
+          description: Failed to fetch analytics data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /api/status:
+    get:
+      operationId: getHealthStatus
+      summary: API health check
+      description: |
+        Simple health-check endpoint. Returns a static success response
+        to confirm the API is running.
+      tags:
+        - status
+      security: []
+      responses:
+        "200":
+          description: API is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              example:
+                ok: true
+                status: healthy
+
+  /api/status/indexing:
+    get:
+      operationId: getIndexingQuota
+      summary: Get Google Indexing API quota status
+      description: |
+        Returns the daily usage and remaining quota for the Google Indexing
+        API. The daily quota is capped at 200 requests. Usage is tracked in
+        the `api_usage` table. Requires a Bearer token for authorization.
+      tags:
+        - status
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Indexing quota status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexingQuotaStatus"
+              example:
+                ok: true
+                apiName: google_indexing
+                used: 45
+                remaining: 155
+                maxDailyQuota: 200
+        "401":
+          description: Missing or malformed Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Unauthorized
+        "403":
+          description: Invalid bearer token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Forbidden
+        "500":
+          description: Server configuration error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Server config error
+
+  /api/indexing:
+    post:
+      operationId: triggerIndexing
+      summary: Trigger full-text search indexing
+      description: |
+        Starts an asynchronous indexing job that reads all MDX posts for
+        every locale (`en`, `ja`, `ko`), extracts title and content from
+        each, and builds an in-memory Fuse.js search index. The `Origin`
+        header must match the server's `NEXT_PUBLIC_BASE_URL`. Returns a
+        job ID that can be polled via `GET /api/indexing?job_id=`.
+      tags:
+        - indexing
+      security: []
+      responses:
+        "200":
+          description: Indexing job created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexingJobCreated"
+              example:
+                job_id: 550e8400-e29b-41d4-a716-446655440000
+                status: pending
+        "403":
+          description: Origin does not match allowed base URL
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                error: Forbidden
+
+    get:
+      operationId: getIndexingJob
+      summary: Get indexing job status or search cache
+      description: |
+        When `job_id` is provided, returns the current status of the
+        indexing job. When omitted, returns the cached Fuse.js search
+        index for the specified language.
+      tags:
+        - indexing
+      security: []
+      parameters:
+        - name: job_id
+          in: query
+          required: false
+          description: UUID of the indexing job to check
+          schema:
+            type: string
+            format: uuid
+        - name: lang
+          in: query
+          required: false
+          description: Language code for the cached search index
+          schema:
+            type: string
+            enum:
+              - en
+              - ja
+              - ko
+            default: en
+      responses:
+        "200":
+          description: Job status or search cache
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/IndexingJobStatus"
+                  - type: array
+                    items:
+                      $ref: "#/components/schemas/SearchEntry"
+              examples:
+                jobStatus:
+                  summary: Job in progress
+                  value:
+                    status: processing
+                    started: 1719835200000
+                completed:
+                  summary: Job completed
+                  value:
+                    status: completed
+                    started: 1719835200000
+                    finished: 1719835260000
+                cache:
+                  summary: Cached search index
+                  value:
+                    - title: My First Post
+                      content: "Lorem ipsum dolor sit amet..."
+                      link: /en/blog/tech/my-first-post
+                      type: post
+                      lang: en
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        Bearer token for internal/cron endpoints.
+        Validated against the server-side `HACKERNEWS_API_KEY` environment variable.
+
+  parameters:
+    Fingerprint:
+      name: fingerprint
+      in: path
+      required: true
+      description: Unique device/browser fingerprint identifier
+      schema:
+        type: string
+
+  schemas:
+    # ── Responses ──────────────────────────────────────────────
+
+    OkResponse:
+      type: object
+      required:
+        - ok
+      properties:
+        ok:
+          type: boolean
+
+    VisitorFound:
+      type: object
+      required:
+        - ok
+        - found
+        - data
+      properties:
+        ok:
+          type: boolean
+          const: true
+        found:
+          type: boolean
+          const: true
+        data:
+          $ref: "#/components/schemas/VisitorFingerprint"
+
+    VisitorNotFound:
+      type: object
+      required:
+        - ok
+        - found
+      properties:
+        ok:
+          type: boolean
+          const: false
+        found:
+          type: boolean
+          const: false
+
+    VisitorFingerprint:
+      type: object
+      description: Visitor record from the `visitor_fingerprint` table
+      required:
+        - id
+        - fingerprint
+        - is_bot
+        - first_visited
+        - last_visited
+        - visit_count
+      properties:
+        id:
+          type: string
+          format: uuid
+        fingerprint:
+          type: string
+        user_agent:
+          type:
+            - string
+            - "null"
+        ip_address:
+          type:
+            - string
+            - "null"
+        country:
+          type:
+            - string
+            - "null"
+          description: ISO country code from Cloudflare `cf-ipcountry` header
+        is_bot:
+          type: boolean
+          description: Detected via user-agent pattern matching
+        first_visited:
+          type: string
+          format: date-time
+        last_visited:
+          type: string
+          format: date-time
+        visit_count:
+          type: integer
+
+    AnalyticsResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/AnalyticsRow"
+
+    AnalyticsRow:
+      type: object
+      required:
+        - date
+        - activeUsers
+      properties:
+        date:
+          type: string
+          description: Date in `YYYYMMDD` format
+        activeUsers:
+          type: string
+          description: Number of active users (returned as string by GA4)
+
+    HealthResponse:
+      type: object
+      required:
+        - ok
+        - status
+      properties:
+        ok:
+          type: boolean
+        status:
+          type: string
+
+    IndexingQuotaStatus:
+      type: object
+      required:
+        - ok
+        - apiName
+        - used
+        - remaining
+        - maxDailyQuota
+      properties:
+        ok:
+          type: boolean
+        apiName:
+          type: string
+          description: Name of the tracked API (e.g. `google_indexing`)
+        used:
+          type: integer
+          description: Number of API calls used today
+        remaining:
+          type: integer
+          description: Remaining calls before hitting the daily quota
+        maxDailyQuota:
+          type: integer
+          description: Maximum allowed API calls per day
+
+    IndexingJobCreated:
+      type: object
+      required:
+        - job_id
+        - status
+      properties:
+        job_id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          const: pending
+
+    IndexingJobStatus:
+      type: object
+      required:
+        - status
+        - started
+      properties:
+        status:
+          type: string
+          enum:
+            - pending
+            - processing
+            - completed
+            - failed
+        started:
+          type: integer
+          description: Job start time (Unix timestamp in milliseconds)
+        finished:
+          type: integer
+          description: Job end time (Unix timestamp in milliseconds)
+        error:
+          type: string
+          description: Error message (present only when status is `failed`)
+
+    SearchEntry:
+      type: object
+      description: Cached full-text search entry built from MDX frontmatter
+      required:
+        - title
+        - content
+        - link
+        - type
+        - lang
+      properties:
+        title:
+          type: string
+        content:
+          type: string
+        link:
+          type: string
+          description: Locale-prefixed post path (e.g. `/en/blog/tech/my-post`)
+        type:
+          type: string
+          const: post
+        lang:
+          type: string
+          enum:
+            - en
+            - ja
+            - ko
+
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Human-readable error message
+
+    # ── Request bodies ────────────────────────────────────────
+
+    RecordVisitorRequest:
+      type: object
+      required:
+        - fingerprint
+      properties:
+        fingerprint:
+          type: string
+          description: Unique device/browser fingerprint identifier


### PR DESCRIPTION
## Summary

Add OpenAPI 3.1.0 specification for 6 Visitor & Analytics API endpoints based on the existing Next.js blog implementation.

## Type

- [ ] README update
- [x] API documentation
- [ ] ADR (Architecture Decision Record)
- [ ] Code comments
- [ ] Other:

## Changes

- [x] `contracts/openapi/visitor.yaml` created with 8 operations across 6 paths
- [x] Visitor endpoints: `POST /api/visitor`, `GET /api/visitor/{fingerprint}`
- [x] Analytics endpoint: `GET /api/google/analytics`
- [x] Status endpoints: `GET /api/status`, `GET /api/status/indexing`
- [x] Indexing endpoints: `POST /api/indexing`, `GET /api/indexing`
- [x] `VisitorFingerprint` and `VisitorFound`/`VisitorNotFound` schemas defined
- [x] `HealthResponse`, `IndexingQuotaStatus`, `IndexingJobStatus`, `SearchEntry` schemas defined
- [x] Bearer auth security scheme for `/api/status/indexing`

## Checklist

- [x] No typos or grammatical errors
- [x] Links are valid
- [x] Code examples tested (if applicable)
- [x] Follows documentation style guide

Closes #8