### PR TITLE
feat: add NAT Gateway toggle for private EC2 internet access

### DIFF
--- a/infra/terraform/live/prod/aws/main.tf
+++ b/infra/terraform/live/prod/aws/main.tf
@@ -9,7 +9,10 @@
 module "network" {
   source = "../../../modules/network"
 
-  vpc_id = var.vpc_id
+  vpc_id                  = var.vpc_id
+  nat_enabled             = var.nat_enabled
+  nat_subnet_id           = var.nat_subnet_id
+  nat_private_route_table_ids = var.nat_private_route_table_ids
 }
 
 # =============================================================================
@@ -46,30 +49,35 @@ module "observability" {
 # 1. Outputs - Network
 # =============================================================================
 
-# output "network_vpcs" {
-#   description = "VPC details"
-#   value       = module.network.vpcs
-# }
+output "network_vpcs" {
+  description = "VPC details"
+  value       = module.network.vpcs
+}
 
-# output "network_subnet_details" {
-#   description = "Subnet details"
-#   value       = module.network.subnet_details
-# }
+output "network_subnet_details" {
+  description = "Subnet details"
+  value       = module.network.subnet_details
+}
 
-# output "network_route_tables" {
-#   description = "Route table details"
-#   value       = module.network.route_table_details
-# }
+output "network_route_tables" {
+  description = "Route table details"
+  value       = module.network.route_table_details
+}
 
-# output "network_availability_zones" {
-#   description = "Available AZs"
-#   value       = module.network.availability_zones
-# }
+output "network_availability_zones" {
+  description = "Available AZs"
+  value       = module.network.availability_zones
+}
 
-# output "network_summary" {
-#   description = "Network summary"
-#   value       = module.network.summary
-# }
+output "network_summary" {
+  description = "Network summary"
+  value       = module.network.summary
+}
+
+output "network_nat_gateway" {
+  description = "NAT Gateway details"
+  value       = module.network.nat_gateway
+}
 
 # =============================================================================
 # 2. Outputs - Security

--- a/infra/terraform/live/prod/aws/terraform.tfvars.example
+++ b/infra/terraform/live/prod/aws/terraform.tfvars.example
@@ -15,3 +15,6 @@ aws_region = "ap-northeast-1" # Tokyo
 # -----------------------------------------------------------------------------
 # vpc_id = ""                  # Empty = query all VPCs
 # vpc_id = "vpc-xxxxxxxxx"    # Specific VPC
+# nat_enabled                 = false              # true = create NAT Gateway, false = destroy (cost saving)
+# nat_subnet_id               = "subnet-xxxxxxxx"  # Public subnet to place NAT Gateway in
+# nat_private_route_table_ids = ["rtb-xxxxxxxx"]   # Private subnet route table IDs

--- a/infra/terraform/live/prod/aws/variables.tf
+++ b/infra/terraform/live/prod/aws/variables.tf
@@ -18,6 +18,24 @@ variable "vpc_id" {
   default     = ""
 }
 
+variable "nat_enabled" {
+  description = "Create a NAT Gateway for private subnet internet access"
+  type        = bool
+  default     = false
+}
+
+variable "nat_subnet_id" {
+  description = "Subnet ID to place the NAT Gateway in (must have IGW route)"
+  type        = string
+  default     = ""
+}
+
+variable "nat_private_route_table_ids" {
+  description = "Route table IDs of private subnets to add NAT route to"
+  type        = list(string)
+  default     = []
+}
+
 # =============================================================================
 # Security Module Variables
 # =============================================================================

--- a/infra/terraform/modules/network/main.tf
+++ b/infra/terraform/modules/network/main.tf
@@ -1,6 +1,39 @@
 # =============================================================================
 # Network Module - Resource Creation
 # =============================================================================
-# Currently query-only (data sources only)
-# NAT Gateway toggle and other resources will be added here
+
+locals {
+  nat_create = var.nat_enabled && var.nat_subnet_id != ""
+}
+
 # =============================================================================
+# NAT Gateway (toggle via nat_enabled)
+# =============================================================================
+
+resource "aws_eip" "nat" {
+  count  = local.nat_create ? 1 : 0
+  domain = "vpc"
+
+  tags = {
+    Name = "blog-v2-nat-eip"
+  }
+}
+
+resource "aws_nat_gateway" "main" {
+  count         = local.nat_create ? 1 : 0
+  allocation_id = aws_eip.nat[0].id
+  subnet_id     = var.nat_subnet_id
+
+  tags = {
+    Name = "blog-v2-nat-gateway"
+  }
+}
+
+# Route 0.0.0.0/0 → NAT Gateway for each private subnet route table
+resource "aws_route" "private_nat" {
+  for_each = local.nat_create ? toset(var.nat_private_route_table_ids) : toset([])
+
+  route_table_id         = each.value
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.main[0].id
+}

--- a/infra/terraform/modules/network/outputs.tf
+++ b/infra/terraform/modules/network/outputs.tf
@@ -64,6 +64,29 @@ output "route_table_details" {
 }
 
 # =============================================================================
+# NAT Gateway
+# =============================================================================
+
+output "nat_gateway" {
+  description = "NAT Gateway details (null when disabled)"
+  value = local.nat_create ? {
+    enabled         = true
+    nat_gateway_id  = aws_nat_gateway.main[0].id
+    eip_public_ip   = aws_eip.nat[0].public_ip
+    eip_id          = aws_eip.nat[0].id
+    subnet_id       = var.nat_subnet_id
+    route_table_ids = toset(var.nat_private_route_table_ids)
+  } : {
+    enabled         = false
+    nat_gateway_id  = null
+    eip_public_ip   = null
+    eip_id          = null
+    subnet_id       = null
+    route_table_ids = toset([])
+  }
+}
+
+# =============================================================================
 # Availability Zones
 # =============================================================================
 

--- a/infra/terraform/modules/network/variables.tf
+++ b/infra/terraform/modules/network/variables.tf
@@ -7,3 +7,21 @@ variable "vpc_id" {
   type        = string
   default     = ""
 }
+
+variable "nat_enabled" {
+  description = "Create a NAT Gateway for private subnet internet access. Requires vpc_id to be set."
+  type        = bool
+  default     = false
+}
+
+variable "nat_subnet_id" {
+  description = "Subnet ID to place the NAT Gateway in (must have IGW route). Required when nat_enabled = true."
+  type        = string
+  default     = ""
+}
+
+variable "nat_private_route_table_ids" {
+  description = "Route table IDs of private subnets to add NAT route to. Required when nat_enabled = true."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

Add a toggleable NAT Gateway to the network module, allowing private EC2 instances to access the internet on demand while minimizing costs when not needed.

## Motivation

Private EC2 instances need outbound internet access for tasks like package updates (`apt update`, `pip install`) and external API calls. A permanently running NAT Gateway costs ~$32+/month even with zero traffic. This toggle approach eliminates idle costs by creating/destroying the NAT Gateway via a single variable.

Closes #23

## Changes

- [x] Add `nat_enabled`, `nat_subnet_id`, `nat_private_route_table_ids` variables to network module
- [x] Add EIP + NAT Gateway + private subnet route resources in `modules/network/main.tf`
- [x] Add `nat_gateway` output with gateway ID, EIP, and associated route tables
- [x] Wire variables through prod environment (`live/prod/aws/`)
- [x] Uncomment network outputs in prod `main.tf`
- [x] Update `terraform.tfvars.example` with NAT configuration examples

## Screenshots / Demo

N/A — Infrastructure change verified via `terraform plan`:

```
Plan: 4 to add, 0 to change, 0 to destroy.
  + aws_eip.nat[0]
  + aws_nat_gateway.main[0]
  + aws_route.private_nat["rtb-08c5ca7510cfbb24e"]
  + aws_route.private_nat["rtb-0fa70ea4427599922"]
```

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in this PR)
- [x] Follows project coding conventions