### PR TITLE
fix: remove go.sum reference from Go service Dockerfile

### DIFF
--- a/services/go/Dockerfile
+++ b/services/go/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.26 AS builder
 WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
+COPY go.mod ./
 COPY . .
 RUN CGO_ENABLED=0 go build -o blog-go-api .
 


### PR DESCRIPTION
## Summary
- Remove `go.sum` from `COPY` command in `services/go/Dockerfile` since the Go service has no external dependencies
- Remove unnecessary `RUN go mod download` step
- Fixes the `build-go` job failure that blocks the entire CD pipeline

Closes #37

## Test plan
- [ ] Verify `build-go` job passes in CD pipeline
- [ ] Verify `deploy` job proceeds after all builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)