### PR TITLE
Add V0003 migration: post_contents, assets, post_assets tables

### DIFF
--- a/infra/db/migrations/V0003__create_post_contents_table.sql
+++ b/infra/db/migrations/V0003__create_post_contents_table.sql
@@ -1,0 +1,63 @@
+-- V3: Create post_contents, assets, and post_assets tables
+
+CREATE TABLE public.post_contents (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    post_id uuid NOT NULL,
+    lang text NOT NULL,
+    content_type text NOT NULL,
+    title text NULL,
+    excerpt text NULL,
+    body_markdown text NULL,
+    body_json jsonb NULL,
+    body_text text NULL,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp DEFAULT now() NULL,
+    updated_at timestamp DEFAULT now() NULL,
+    CONSTRAINT post_contents_pkey PRIMARY KEY (id),
+    CONSTRAINT post_contents_post_id_fkey
+        FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE,
+    CONSTRAINT unique_post_content_lang UNIQUE (post_id, lang)
+);
+
+CREATE INDEX idx_post_contents_lang
+ON public.post_contents USING btree (lang);
+
+CREATE INDEX idx_post_contents_content_type
+ON public.post_contents USING btree (content_type);
+
+-- assets
+CREATE TABLE public.assets (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    bucket text NOT NULL,
+    object_key text NOT NULL,
+    file_name text NOT NULL,
+    mime_type text NOT NULL,
+    size_bytes bigint NOT NULL,
+    sha256 text NULL,
+    width integer NULL,
+    height integer NULL,
+    duration_ms integer NULL,
+    kind text NOT NULL,
+    status text NOT NULL DEFAULT 'active',
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp DEFAULT now() NULL,
+    updated_at timestamp DEFAULT now() NULL,
+    CONSTRAINT assets_pkey PRIMARY KEY (id),
+    CONSTRAINT assets_object_key_key UNIQUE (bucket, object_key)
+);
+
+-- post_assets
+CREATE TABLE public.post_assets (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    post_id uuid NOT NULL,
+    asset_id uuid NOT NULL,
+    lang text NULL,
+    role text NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    created_at timestamp DEFAULT now() NULL,
+    CONSTRAINT post_assets_pkey PRIMARY KEY (id),
+    CONSTRAINT post_assets_post_id_fkey
+        FOREIGN KEY (post_id) REFERENCES public.posts(id) ON DELETE CASCADE,
+    CONSTRAINT post_assets_asset_id_fkey
+        FOREIGN KEY (asset_id) REFERENCES public.assets(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary

Add Flyway migration `V0003__create_post_contents_table.sql` to introduce three new tables (`post_contents`, `assets`, `post_assets`) that separate content and media from the existing `posts` metadata table.

## Motivation

Closes #39

The existing `posts` table serves as a document registry (classification, category, slug, indexing state). Rather than bloating it with content columns, we separate actual content (markdown, JSON, rendered text) and media assets into dedicated tables for cleaner separation of concerns.

## Changes

- [x] `post_contents` — stores multilingual content (markdown, JSON, rendered text, metadata) with a 1:N relationship to `posts` via `UNIQUE(post_id, lang)`
- [x] `assets` — stores file/media metadata (S3 bucket, object key, mime type, dimensions, etc.)
- [x] `post_assets` — join table linking posts to assets with language, role, and sort order
- [x] Indexes on `lang`, `content_type` for `post_contents`

## Screenshots / Demo

N/A — database migration only

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented in this PR)
- [x] Follows project coding conventions