### PR TITLE
Add explicit Flyway migration step to CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -151,6 +151,11 @@ jobs:
 
             # Deploy with release version tag
             IMAGE_TAG=${{ env.VERSION }} docker compose --env-file .env.prod -f docker-compose.prod.yml pull
+
+            # Run Flyway migration (force recreate to apply new migrations)
+            IMAGE_TAG=${{ env.VERSION }} docker compose --env-file .env.prod -f docker-compose.prod.yml run --rm flyway migrate
+
+            # Start API services
             IMAGE_TAG=${{ env.VERSION }} docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 
             # Cleanup old images


### PR DESCRIPTION
## Summary

Add an explicit `docker compose run --rm flyway migrate` step in the CD deploy script so that Flyway migrations are guaranteed to run on every release deployment.

## Motivation

Closes #41

Previously, the deploy script relied solely on `docker compose up -d`, which may not re-run the flyway container if it already exited from a prior deployment. This means new migration files could be downloaded but never applied.

## Changes

- [x] Added `docker compose run --rm flyway migrate` before `docker compose up -d` in the CD deploy step
- [x] Migration failure will halt deployment (`set -e`) — API services won't start with an outdated schema

## Screenshots / Demo

N/A — CI/CD workflow change only

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented in this PR)
- [x] Follows project coding conventions