### PR TITLE
fix: align Rust runtime base image with builder to resolve GLIBC mismatch

### DIFF
--- a/services/auth/Dockerfile
+++ b/services/auth/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && r
 COPY src ./src
 RUN touch src/main.rs && cargo build --release
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/blog-auth-api /usr/local/bin/
 EXPOSE 8001

--- a/services/rust/Dockerfile
+++ b/services/rust/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && r
 COPY src ./src
 RUN touch src/main.rs && cargo build --release
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/blog-rust-api /usr/local/bin/
 EXPOSE 8002


### PR DESCRIPTION
## Summary

- `rust:1.93` builder is Debian trixie-based (GLIBC 2.38/2.39), but runtime was `bookworm-slim` (GLIBC 2.36)
- Both rust-api and auth-api crashed on startup with `GLIBC_2.38 not found`
- Changed runtime base image from `debian:bookworm-slim` → `debian:trixie-slim` for both services

## Type

- [x] Configuration change

## Changes

- [x] `services/rust/Dockerfile`: bookworm-slim → trixie-slim
- [x] `services/auth/Dockerfile`: bookworm-slim → trixie-slim

## Risk Assessment

Low — only changes the runtime base image to match what the builder already uses.

## Checklist

- [ ] CI passes
- [x] No breaking changes to development workflow
- [ ] Tested locally (if applicable)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)