### PR TITLE
feat: add local observability stack (Grafana, Alloy, Loki, Tempo)

### DIFF
--- a/infra/docker/compose.local.yml
+++ b/infra/docker/compose.local.yml
@@ -157,6 +157,58 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - dozzle_data:/data
 
+  # Observability stack
+  loki:
+    image: grafana/loki:3.7.0
+    container_name: blog-loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki/loki-config.yml:/etc/loki/config.yaml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/config.yaml
+
+  tempo:
+    image: grafana/tempo:2.10.3
+    container_name: blog-tempo
+    ports:
+      - "3200:3200"
+    volumes:
+      - ./observability/tempo/tempo-config.yml:/etc/tempo/config.yaml:ro
+      - tempo_data:/var/tempo
+    command: -config.file=/etc/tempo/config.yaml
+
+  alloy:
+    image: grafana/alloy:v1.15.0
+    container_name: blog-alloy
+    ports:
+      - "4317:4317"  # OTLP gRPC
+      - "4318:4318"  # OTLP HTTP
+      - "12345:12345"  # Alloy UI / debug
+    volumes:
+      - ./observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
+    command: run /etc/alloy/config.alloy --server.http.listen-addr=0.0.0.0:12345
+    depends_on:
+      - loki
+      - tempo
+
+  grafana:
+    image: grafana/grafana:12.4.0
+    container_name: blog-grafana
+    ports:
+      - "9000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - loki
+      - tempo
+
 volumes:
   redis_data:
   redisinsight_data:
@@ -169,3 +221,6 @@ volumes:
   haskell_cabal_cache:
   haskell_cabal_store:
   dozzle_data:
+  loki_data:
+  tempo_data:
+  grafana_data:

--- a/infra/docker/observability/alloy/config.alloy
+++ b/infra/docker/observability/alloy/config.alloy
@@ -1,0 +1,39 @@
+// OTLP receiver: accepts logs and traces from application services
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4317"
+  }
+  http {
+    endpoint = "0.0.0.0:4318"
+  }
+
+  output {
+    logs  = [otelcol.processor.batch.default.input]
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Batch processor: buffers telemetry for efficient export
+otelcol.processor.batch "default" {
+  output {
+    logs  = [otelcol.exporter.otlphttp.loki.input]
+    traces = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+
+// Export logs to Loki via OTLP HTTP
+otelcol.exporter.otlphttp "loki" {
+  client {
+    endpoint = "http://loki:3100/otlp"
+  }
+}
+
+// Export traces to Tempo via OTLP gRPC
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo:4317"
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/infra/docker/observability/grafana/provisioning/datasources/datasources.yml
+++ b/infra/docker/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,25 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: '"traceID":"(\w+)"'
+          name: TraceID
+          url: "${__value.raw}"
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    uid: tempo
+    url: http://tempo:3200
+    jsonData:
+      tracesToLogs:
+        datasourceUid: loki
+        tags:
+          - service.name

--- a/infra/docker/observability/loki/loki-config.yml
+++ b/infra/docker/observability/loki/loki-config.yml
@@ -1,0 +1,33 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: "2024-01-01"
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_query_length: 721h
+
+compactor:
+  working_directory: /loki/compactor

--- a/infra/docker/observability/tempo/tempo-config.yml
+++ b/infra/docker/observability/tempo/tempo-config.yml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal


### PR DESCRIPTION
## Summary

Add a local observability stack to `infra/docker/compose.local.yml` with Grafana, Alloy, Loki, and Tempo for log aggregation and distributed tracing.

## Motivation

Closes #53. Enables structured log querying (Loki) and distributed tracing (Tempo) for all backend services in the local dev environment, with Grafana as the unified UI.

## Changes

- [x] Add Loki, Tempo, Alloy, Grafana services to `compose.local.yml`
- [x] Add Alloy config (`observability/alloy/config.alloy`) — OTLP receiver → Loki/Tempo exporters
- [x] Add Loki config (`observability/loki/loki-config.yml`) — single-tenant, filesystem storage
- [x] Add Tempo config (`observability/tempo/tempo-config.yml`) — local storage
- [x] Add Grafana datasource provisioning (`observability/grafana/provisioning/datasources/datasources.yml`) — auto-provision Loki + Tempo with log↔trace linking
- [x] Add named volumes (`loki_data`, `tempo_data`, `grafana_data`)

## Screenshots / Demo

N/A

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented in this PR)
- [x] Follows project coding conventions