### PR TITLE
fix: add delete_request_store to Loki prod compactor config

### DIFF
--- a/infra/docker/observability/loki/loki-config.prod.yml
+++ b/infra/docker/observability/loki/loki-config.prod.yml
@@ -33,4 +33,5 @@ limits_config:
 compactor:
   working_directory: /loki/compactor
   retention_enabled: true
+  delete_request_store: filesystem
   compaction_interval: 10m


### PR DESCRIPTION
## Summary

Add missing `delete_request_store: filesystem` to Loki production compactor config to resolve startup crash.

## Type

- [ ] Dependency update
- [x] Configuration change
- [ ] CI/CD update
- [ ] Build tooling
- [ ] Other:

## Changes

- [x] Add `delete_request_store: filesystem` to `loki-config.prod.yml` compactor section

## Risk Assessment

Low — single line config addition, required by Loki when retention is enabled.

## Checklist

- [x] CI passes
- [x] No breaking changes to development workflow
- [x] Tested locally (if applicable)

Closes #57