### PR TITLE
feat: automate Hacker News pipeline via GitHub Actions

### DIFF
--- a/.github/workflows/hackernews-pipeline.yml
+++ b/.github/workflows/hackernews-pipeline.yml
@@ -21,7 +21,10 @@ env:
 jobs:
   pipeline:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
+    concurrency:
+      group: hackernews-pipeline
+      cancel-in-progress: false
 
     steps:
       - name: Resolve target date
@@ -166,17 +169,20 @@ jobs:
         run: |
           DATE="${{ steps.date.outputs.value }}"
           echo "==> POST /hackernews/draw/${DATE}"
-          curl -sf -X POST "${BACKEND_GO_URL}/hackernews/draw/${DATE}" \
-            -H "Authorization: Bearer ${HACKERNEWS_SECRET}"
+          DRAW_RESP=$(curl -sf -X POST "${BACKEND_GO_URL}/hackernews/draw/${DATE}" \
+            -H "Authorization: Bearer ${HACKERNEWS_SECRET}")
+          DRAW_OK=$(echo "$DRAW_RESP" | jq -r '.ok')
+          if [ "$DRAW_OK" != "true" ]; then
+            echo "Draw rejected: $(echo "$DRAW_RESP" | jq -r '.error // .message // "unknown"')"
+            exit 1
+          fi
 
+          # draw is a single image generation; wait for it to finish
           for i in $(seq 1 20); do
             sleep 15
             STATUS=$(curl -sf "${BACKEND_GO_URL}/hackernews/status/${DATE}" \
               -H "Authorization: Bearer ${HACKERNEWS_SECRET}")
             echo "  [$i] $(echo "$STATUS" | jq -c '.')"
-
-            # draw has no dedicated status endpoint; check pipeline status
-            # draw is done quickly (single image), give it time then move on
             if [ "$i" -ge 4 ]; then
               echo "Draw step waited 60s — proceeding."
               break


### PR DESCRIPTION
## Summary

Add a scheduled GitHub Actions workflow that runs the full Hacker News translation pipeline daily (fetch → summarize → translate → draw → import).

## Motivation

The HN pipeline currently requires manual API calls to trigger each phase. This workflow automates the entire process on a daily cron schedule (04:00 JST), with duplicate detection to skip dates already imported.

Closes #63

## Changes

- [x] Add `.github/workflows/hackernews-pipeline.yml`
  - Cron schedule at 04:00 JST (19:00 UTC)
  - `workflow_dispatch` support for manual runs with optional date input
  - Duplicate check via Rust API (`/posts/trends/hackernews`) before running
  - Sequential pipeline: fetch → summarize → translate(ko) → translate(ja) → draw → import
  - Status polling between each phase
  - Final import to DB via Rust `/import/json`

## Screenshots / Demo

N/A — CI/CD workflow, no UI changes.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or documented in this PR)
- [x] Follows project coding conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)