### PR TITLE
feat(go): add HN inspection endpoints and pipeline backfill mode

### DIFF
--- a/.github/workflows/hackernews-pipeline.yml
+++ b/.github/workflows/hackernews-pipeline.yml
@@ -38,14 +38,23 @@ jobs:
               exit 1
             fi
             echo "value=$INPUT_DATE" >> "$GITHUB_OUTPUT"
+            echo "manual=true" >> "$GITHUB_OUTPUT"
+            echo "Manual date override: $INPUT_DATE (backfill mode)"
           else
             echo "value=$(TZ=Asia/Tokyo date +'%y%m%d')" >> "$GITHUB_OUTPUT"
+            echo "manual=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if posts already exist
         id: check
         run: |
           DATE="${{ steps.date.outputs.value }}"
+          MANUAL="${{ steps.date.outputs.manual }}"
+          if [ "$MANUAL" = "true" ]; then
+            echo "Backfill mode for $DATE — skipping existence check and proceeding."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           RESP=$(curl -sf "${BACKEND_RUST_URL}/posts/trends/hackernews?lang=ko&page=1&per_page=100" || echo '{"posts":[]}')
           EXISTS=$(echo "$RESP" | jq -r --arg d "$DATE" '.posts[]? | select(.slug == $d) | .slug')
           if [ -n "$EXISTS" ]; then
@@ -57,7 +66,7 @@ jobs:
           fi
 
       - name: Collect articles from HN
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.skip == 'false' && steps.date.outputs.manual == 'false'
         run: |
           DATE="${{ steps.date.outputs.value }}"
           echo "==> GET /hackernews/${DATE}"

--- a/services/go/internal/config/config.go
+++ b/services/go/internal/config/config.go
@@ -7,12 +7,12 @@ import (
 
 type Config struct {
 	// S3-compatible (Cloudflare R2)
-	S3Endpoint              string
+	S3Endpoint                   string
 	S3BucketBlogHackernews       string
 	S3BucketBlogHackernewsImages string
-	AWSAccessKeyID     string
-	AWSSecretAccessKey string
-	AWSRegion          string
+	AWSAccessKeyID               string
+	AWSSecretAccessKey           string
+	AWSRegion                    string
 
 	// Redis
 	RedisURL string
@@ -22,6 +22,7 @@ type Config struct {
 
 	// App
 	HackernewsSecret string
+	RustAPIURL       string
 }
 
 func Load() *Config {
@@ -35,6 +36,7 @@ func Load() *Config {
 		RedisURL:                     getEnv("REDIS_URL", "redis://localhost:6379"),
 		OpenAIAPIKey:                 getEnv("OPENAI_API_KEY", ""),
 		HackernewsSecret:             getEnv("HACKERNEWS_SECRET", ""),
+		RustAPIURL:                   getEnv("RUST_API_URL", "http://localhost:8002"),
 	}
 
 	required := map[string]string{

--- a/services/go/internal/handler/inspect.go
+++ b/services/go/internal/handler/inspect.go
@@ -98,7 +98,9 @@ func InspectJSONHandler(cfg *config.Config, r2c *r2.Client) http.HandlerFunc {
 	}
 }
 
-// InspectWebpHandler checks R2 for missing hackernews-images/{YYMMDD}.webp files.
+// InspectWebpHandler checks R2 for missing hackernews-images/{YYMMDD}.{webp,png} files.
+// Historical data was stored as .webp; newer uploads from DrawHandler are .png,
+// so a date is considered "found" if either extension exists.
 func InspectWebpHandler(cfg *config.Config, r2c *r2.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !common.CheckAuth(r, cfg.HackernewsSecret) {
@@ -128,6 +130,13 @@ func InspectWebpHandler(cfg *config.Config, r2c *r2.Client) http.HandlerFunc {
 			if err != nil {
 				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
+			}
+			if !exists {
+				exists, err = r2c.Exists(d + ".png")
+				if err != nil {
+					common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+					return
+				}
 			}
 			if !exists {
 				missing = append(missing, d)

--- a/services/go/internal/handler/inspect.go
+++ b/services/go/internal/handler/inspect.go
@@ -1,0 +1,232 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"blog-go-api/internal/common"
+	"blog-go-api/internal/config"
+	"blog-go-api/internal/r2"
+)
+
+var kst = time.FixedZone("KST", 9*60*60)
+
+type inspectResult struct {
+	From       string            `json:"from"`
+	To         string            `json:"to"`
+	Total      int               `json:"total"`
+	Found      int               `json:"found"`
+	Missing    []string          `json:"missing"`
+	Incomplete []incompleteEntry `json:"incomplete,omitempty"`
+}
+
+type incompleteEntry struct {
+	Date             string   `json:"date"`
+	MissingLanguages []string `json:"missing_languages"`
+}
+
+// dateRange generates YYMMDD strings from `from` to `to` inclusive.
+func dateRange(from, to string) ([]string, error) {
+	start, err := time.Parse("060102", from)
+	if err != nil {
+		return nil, fmt.Errorf("invalid from date %q: %w", from, err)
+	}
+	end, err := time.Parse("060102", to)
+	if err != nil {
+		return nil, fmt.Errorf("invalid to date %q: %w", to, err)
+	}
+	if start.After(end) {
+		return nil, fmt.Errorf("from (%s) is after to (%s)", from, to)
+	}
+
+	var dates []string
+	for d := start; !d.After(end); d = d.AddDate(0, 0, 1) {
+		dates = append(dates, d.Format("060102"))
+	}
+	return dates, nil
+}
+
+func todayKST() string {
+	return time.Now().In(kst).Format("060102")
+}
+
+// InspectJSONHandler checks R2 for missing hackernews/{YYMMDD}.json files.
+func InspectJSONHandler(cfg *config.Config, r2c *r2.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !common.CheckAuth(r, cfg.HackernewsSecret) {
+			common.WriteJSON(w, http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+			return
+		}
+
+		from := r.URL.Query().Get("from")
+		to := r.URL.Query().Get("to")
+		if from == "" {
+			common.WriteJSON(w, http.StatusBadRequest, map[string]string{"error": "from is required (YYMMDD)"})
+			return
+		}
+		if to == "" {
+			to = todayKST()
+		}
+
+		dates, err := dateRange(from, to)
+		if err != nil {
+			common.WriteJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		var missing []string
+		for _, d := range dates {
+			exists, err := r2c.Exists(d + ".json")
+			if err != nil {
+				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			if !exists {
+				missing = append(missing, d)
+			}
+		}
+
+		common.WriteJSON(w, http.StatusOK, inspectResult{
+			From:    from,
+			To:      to,
+			Total:   len(dates),
+			Found:   len(dates) - len(missing),
+			Missing: missing,
+		})
+	}
+}
+
+// InspectWebpHandler checks R2 for missing hackernews-images/{YYMMDD}.webp files.
+func InspectWebpHandler(cfg *config.Config, r2c *r2.Client) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !common.CheckAuth(r, cfg.HackernewsSecret) {
+			common.WriteJSON(w, http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+			return
+		}
+
+		from := r.URL.Query().Get("from")
+		to := r.URL.Query().Get("to")
+		if from == "" {
+			common.WriteJSON(w, http.StatusBadRequest, map[string]string{"error": "from is required (YYMMDD)"})
+			return
+		}
+		if to == "" {
+			to = todayKST()
+		}
+
+		dates, err := dateRange(from, to)
+		if err != nil {
+			common.WriteJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		var missing []string
+		for _, d := range dates {
+			exists, err := r2c.Exists(d + ".webp")
+			if err != nil {
+				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			if !exists {
+				missing = append(missing, d)
+			}
+		}
+
+		common.WriteJSON(w, http.StatusOK, inspectResult{
+			From:    from,
+			To:      to,
+			Total:   len(dates),
+			Found:   len(dates) - len(missing),
+			Missing: missing,
+		})
+	}
+}
+
+// InspectDBHandler checks the Rust API for missing HN posts and language completeness.
+func InspectDBHandler(cfg *config.Config) http.HandlerFunc {
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !common.CheckAuth(r, cfg.HackernewsSecret) {
+			common.WriteJSON(w, http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+			return
+		}
+
+		from := r.URL.Query().Get("from")
+		to := r.URL.Query().Get("to")
+		if from == "" {
+			common.WriteJSON(w, http.StatusBadRequest, map[string]string{"error": "from is required (YYMMDD)"})
+			return
+		}
+		if to == "" {
+			to = todayKST()
+		}
+
+		dates, err := dateRange(from, to)
+		if err != nil {
+			common.WriteJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		var missing []string
+		var incomplete []incompleteEntry
+
+		for _, d := range dates {
+			url := fmt.Sprintf("%s/posts/trends/hackernews/%s", cfg.RustAPIURL, d)
+			resp, err := client.Get(url)
+			if err != nil {
+				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to call rust api for %s: %v", d, err)})
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode == http.StatusNotFound {
+				missing = append(missing, d)
+				continue
+			}
+			if resp.StatusCode != http.StatusOK {
+				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("rust api returned %d for %s", resp.StatusCode, d)})
+				return
+			}
+
+			var post struct {
+				Contents []struct {
+					Lang string `json:"lang"`
+				} `json:"contents"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&post); err != nil {
+				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to decode response for %s: %v", d, err)})
+				return
+			}
+
+			langSet := map[string]bool{}
+			for _, c := range post.Contents {
+				langSet[c.Lang] = true
+			}
+
+			var missingLangs []string
+			for _, lang := range []string{"en", "ko", "ja"} {
+				if !langSet[lang] {
+					missingLangs = append(missingLangs, lang)
+				}
+			}
+			if len(missingLangs) > 0 {
+				incomplete = append(incomplete, incompleteEntry{
+					Date:             d,
+					MissingLanguages: missingLangs,
+				})
+			}
+		}
+
+		common.WriteJSON(w, http.StatusOK, inspectResult{
+			From:       from,
+			To:         to,
+			Total:      len(dates),
+			Found:      len(dates) - len(missing),
+			Missing:    missing,
+			Incomplete: incomplete,
+		})
+	}
+}

--- a/services/go/internal/handler/inspect.go
+++ b/services/go/internal/handler/inspect.go
@@ -173,22 +173,20 @@ func InspectDBHandler(cfg *config.Config) http.HandlerFunc {
 		var missing []string
 		var incomplete []incompleteEntry
 
-		for _, d := range dates {
+		// fetchOne returns (notFound, missingLangs, err). notFound==true means the post is missing.
+		fetchOne := func(d string) (bool, []string, error) {
 			url := fmt.Sprintf("%s/posts/trends/hackernews/%s", cfg.RustAPIURL, d)
 			resp, err := client.Get(url)
 			if err != nil {
-				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to call rust api for %s: %v", d, err)})
-				return
+				return false, nil, fmt.Errorf("failed to call rust api for %s: %v", d, err)
 			}
 			defer resp.Body.Close()
 
 			if resp.StatusCode == http.StatusNotFound {
-				missing = append(missing, d)
-				continue
+				return true, nil, nil
 			}
 			if resp.StatusCode != http.StatusOK {
-				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("rust api returned %d for %s", resp.StatusCode, d)})
-				return
+				return false, nil, fmt.Errorf("rust api returned %d for %s", resp.StatusCode, d)
 			}
 
 			var post struct {
@@ -197,8 +195,7 @@ func InspectDBHandler(cfg *config.Config) http.HandlerFunc {
 				} `json:"contents"`
 			}
 			if err := json.NewDecoder(resp.Body).Decode(&post); err != nil {
-				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("failed to decode response for %s: %v", d, err)})
-				return
+				return false, nil, fmt.Errorf("failed to decode response for %s: %v", d, err)
 			}
 
 			langSet := map[string]bool{}
@@ -211,6 +208,19 @@ func InspectDBHandler(cfg *config.Config) http.HandlerFunc {
 				if !langSet[lang] {
 					missingLangs = append(missingLangs, lang)
 				}
+			}
+			return false, missingLangs, nil
+		}
+
+		for _, d := range dates {
+			notFound, missingLangs, err := fetchOne(d)
+			if err != nil {
+				common.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			if notFound {
+				missing = append(missing, d)
+				continue
 			}
 			if len(missingLangs) > 0 {
 				incomplete = append(incomplete, incompleteEntry{

--- a/services/go/internal/r2/client.go
+++ b/services/go/internal/r2/client.go
@@ -97,6 +97,27 @@ func (c *Client) Put(key string, data []byte, contentType string) error {
 	})
 }
 
+func (c *Client) Exists(key string) (bool, error) {
+	_, err := c.s3.HeadObject(context.TODO(), &s3.HeadObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		var noSuchKey *types.NoSuchKey
+		var notFound *types.NotFound
+		if errors.As(err, &noSuchKey) || errors.As(err, &notFound) {
+			return false, nil
+		}
+		// HeadObject returns 404 as a generic smithy error; check HTTP status
+		var respErr interface{ HTTPStatusCode() int }
+		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+			return false, nil
+		}
+		return false, fmt.Errorf("S3 HEAD %s/%s: %w", c.bucket, key, err)
+	}
+	return true, nil
+}
+
 func (c *Client) PutJSON(key string, v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {

--- a/services/go/internal/r2/client.go
+++ b/services/go/internal/r2/client.go
@@ -98,24 +98,31 @@ func (c *Client) Put(key string, data []byte, contentType string) error {
 }
 
 func (c *Client) Exists(key string) (bool, error) {
-	_, err := c.s3.HeadObject(context.TODO(), &s3.HeadObjectInput{
-		Bucket: aws.String(c.bucket),
-		Key:    aws.String(key),
+	var exists bool
+	err := retry(3, time.Second, func() error {
+		_, err := c.s3.HeadObject(context.TODO(), &s3.HeadObjectInput{
+			Bucket: aws.String(c.bucket),
+			Key:    aws.String(key),
+		})
+		if err != nil {
+			var noSuchKey *types.NoSuchKey
+			var notFound *types.NotFound
+			if errors.As(err, &noSuchKey) || errors.As(err, &notFound) {
+				exists = false
+				return nil
+			}
+			// HeadObject returns 404 as a generic smithy error; check HTTP status
+			var respErr interface{ HTTPStatusCode() int }
+			if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
+				exists = false
+				return nil
+			}
+			return fmt.Errorf("S3 HEAD %s/%s: %w", c.bucket, key, err)
+		}
+		exists = true
+		return nil
 	})
-	if err != nil {
-		var noSuchKey *types.NoSuchKey
-		var notFound *types.NotFound
-		if errors.As(err, &noSuchKey) || errors.As(err, &notFound) {
-			return false, nil
-		}
-		// HeadObject returns 404 as a generic smithy error; check HTTP status
-		var respErr interface{ HTTPStatusCode() int }
-		if errors.As(err, &respErr) && respErr.HTTPStatusCode() == 404 {
-			return false, nil
-		}
-		return false, fmt.Errorf("S3 HEAD %s/%s: %w", c.bucket, key, err)
-	}
-	return true, nil
+	return exists, err
 }
 
 func (c *Client) PutJSON(key string, v any) error {

--- a/services/go/main.go
+++ b/services/go/main.go
@@ -77,6 +77,11 @@ func main() {
 	mux.HandleFunc("POST /hackernews/draw", draw)
 	mux.HandleFunc("POST /hackernews/draw/{date}", draw)
 
+	// Inspect
+	mux.HandleFunc("GET /hackernews/inspect/json", handler.InspectJSONHandler(cfg, hackernewsClient))
+	mux.HandleFunc("GET /hackernews/inspect/webp", handler.InspectWebpHandler(cfg, hackernewsImagesClient))
+	mux.HandleFunc("GET /hackernews/inspect/db", handler.InspectDBHandler(cfg))
+
 	log.Println("go-api listening on :8003")
 	log.Fatal(http.ListenAndServe(":8003", mux))
 }


### PR DESCRIPTION
Closes #68

## Summary

Add three inspection endpoints to the Go service for auditing Hacker News data completeness across arbitrary date ranges, and extend the Hacker News pipeline with a **backfill mode** that lets a manually triggered run re-process an existing date without clobbering the R2 snapshot.

## Motivation

Two pain points:

1. **No way to audit what's missing.** With ~1.5 years of daily HN data split across R2 JSON, R2 cover images (webp), and Postgres, there was no easy way to answer "which dates am I missing?" short of scripting ad-hoc R2 listings and DB queries. This made gap detection tedious and error-prone.
2. **Pipeline couldn't safely re-run historical dates.** The existing workflow always called `GET /hackernews/{date}` to collect articles from the HN API, but HN only returns *current* topstories — so manually triggering the pipeline for an old date would overwrite that date's R2 JSON with today's topstories and permanently lose the original snapshot. Meanwhile, `Check if posts already exist` would short-circuit the run before fetch/summarize/translate could repair partial data.

With these changes, auditing is a single HTTP call and re-running a past date for gap-filling is safe.

## Changes

- [x] **Inspection endpoints (`services/go/internal/handler/inspect.go`)**
  - `GET /hackernews/inspect/json?from=YYMMDD[&to=YYMMDD]` — iterates the date range and issues an R2 `HeadObject` per day against the Hacker News JSON bucket; returns `{ from, to, total, found, missing: [] }`.
  - `GET /hackernews/inspect/webp?from=YYMMDD[&to=YYMMDD]` — same shape but against the cover-image bucket for `{date}.webp`.
  - `GET /hackernews/inspect/db?from=YYMMDD[&to=YYMMDD]` — calls the Rust API `/posts/trends/hackernews/{date}` per day, flags missing posts *and* posts missing any of `en`/`ko`/`ja` via an `incomplete: []` field.
  - `to` is optional; defaults to today in KST (hardcoded `time.FixedZone`, so server TZ is irrelevant).
  - All three handlers require the `HACKERNEWS_SECRET` bearer token.
- [x] **File descriptor safety (`InspectDBHandler`)**
  - Moved the per-date HTTP call into a `fetchOne` closure so `defer resp.Body.Close()` fires every iteration. The earlier draft used `defer` inside the loop, which would hold ~N response bodies open until the handler returned — fine for a few days but risked `too many open files` on multi-year ranges.
- [x] **New R2 client method (`services/go/internal/r2/client.go`)**
  - Added `Exists(key string) (bool, error)` using `HeadObject`, with explicit handling for `NoSuchKey`, `NotFound`, and generic smithy 404 responses (R2 sometimes returns the latter).
- [x] **Config (`services/go/internal/config/config.go`)**
  - Added `RustAPIURL` (env `RUST_API_URL`, default `http://localhost:8002`) so `InspectDBHandler` can reach the Rust service.
- [x] **Pipeline backfill mode (`.github/workflows/hackernews-pipeline.yml`)**
  - `Resolve target date` now emits a `manual` output (`true` when a date was passed via `workflow_dispatch`, `false` for scheduled runs).
  - `Check if posts already exist` short-circuits to `skip=false` when `manual=true`, so backfill runs are not blocked by pre-existing DB rows.
  - `Collect articles from HN` is now gated on `manual == 'false'` — manual runs skip the HN topstories fetch entirely, preserving the original R2 JSON for that date.
  - All downstream steps (fetch, summarize, translate, draw, import) still run, relying on the existing R2 snapshot and the services' built-in *incremental* filters (only processes items with empty `content` / `summary.en` / per-lang fields), so they safely fill gaps without disturbing existing data.
- [x] **Main wiring (`services/go/main.go`)**
  - Registered the three new routes with the appropriate R2 client (`hackernewsClient` for JSON, `hackernewsImagesClient` for webp).

## Screenshots / Demo

Example against local dev:

\`\`\`
GET {{goUrl}}/hackernews/inspect/json?from=250101&to=260430
{
  "from": "250101",
  "to": "260430",
  "total": 485,
  "found": 412,
  "missing": ["250107", "250203", ...]
}
\`\`\`

\`\`\`
GET {{goUrl}}/hackernews/inspect/db?from=260401&to=260408
{
  "from": "260401",
  "to": "260408",
  "total": 8,
  "found": 7,
  "missing": ["260403"],
  "incomplete": [
    { "date": "260405", "missing_languages": ["ja"] }
  ]
}
\`\`\`

Backfill trigger:

\`\`\`
gh workflow run hackernews-pipeline.yml -f date=250324
\`\`\`

Bruno collection (`work/bruno/blog-v2/go/hackernews/inspect/`) updated with three ready-to-run requests.

## Checklist

- [ ] Tests added/updated — no unit tests exist for these handlers; verified manually against \`dev-blog-hackernews\` / \`dev-blog-hackernews-images\` and the prod bucket via env override.
- [x] Documentation updated (if needed) — Bruno collection reflects the new endpoints; no user-facing docs impacted.
- [x] No breaking changes (or documented in this PR) — purely additive for the Go service. The pipeline change is backwards-compatible: scheduled runs behave identically; only manually dispatched runs with an explicit \`date\` input see the new backfill semantics. New optional env var: \`RUST_API_URL\` (defaults to \`http://localhost:8002\`; in prod set it to the internal Rust service URL if \`InspectDBHandler\` is expected to work).
- [x] Follows project coding conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)