### PR TITLE
bug: align auth routes with caddy /auth strip_prefix to fix login 404

### DIFF
--- a/services/auth/src/config/mod.rs
+++ b/services/auth/src/config/mod.rs
@@ -75,6 +75,6 @@ impl AppConfig {
     }
 
     pub fn redirect_uri(&self, provider: &str) -> String {
-        format!("{}/auth/callback/{}", self.backend_auth_url, provider)
+        format!("{}/callback/{}", self.backend_auth_url, provider)
     }
 }

--- a/services/auth/src/routes/mod.rs
+++ b/services/auth/src/routes/mod.rs
@@ -23,16 +23,13 @@ pub fn create_router(state: AppState) -> Router {
         ])
         .allow_credentials(true);
 
-    let auth_routes = Router::new()
+    Router::new()
+        .route("/health", get(health))
         .route("/login/{provider}", get(handlers::login))
         .route("/callback/{provider}", get(handlers::callback))
         .route("/refresh", post(handlers::refresh))
         .route("/logout", post(handlers::logout))
-        .route("/me", get(handlers::me));
-
-    Router::new()
-        .route("/health", get(health))
-        .nest("/auth", auth_routes)
+        .route("/me", get(handlers::me))
         .layer(cors)
         .with_state(state)
 }


### PR DESCRIPTION
## Summary

Production Google login was returning 404 on `https://api.mogumogu.dev/auth/login/google`. Root cause: Caddy strips the `/auth` prefix (`uri strip_prefix /auth`) before forwarding to the auth-api container, but the code re-nested every route under `.nest("/auth", ...)`. After strip the container received `/login/google`, which did not exist. The OAuth `redirect_uri` was also being constructed with a duplicate `/auth` segment for the same reason.

Closes #74

## Type

- [ ] Dependency update
- [ ] Configuration change
- [ ] CI/CD update
- [ ] Build tooling
- [x] Other: route/path alignment with reverse proxy

## Changes

- [x] Remove `.nest("/auth", auth_routes)` in `services/auth/src/routes/mod.rs` and register routes flat on the root router
- [x] Drop the `/auth/` segment from `redirect_uri()` in `services/auth/src/config/mod.rs` so the formula becomes `{backend_auth_url}/callback/{provider}`. With `BACKEND_AUTH_URL=https://api.mogumogu.dev/auth`, the resulting redirect_uri is `https://api.mogumogu.dev/auth/callback/google`, matching the path Caddy expects after strip_prefix
- [x] Caddyfile and `.env.prod` are intentionally untouched — fix is contained to blog-v2

## Risk Assessment

Low. Two-line behavioral change in a single service. No schema or contract changes. The new external URL surface is identical to what Caddy already routes (`/auth/{login,callback,refresh,logout,me}`); only the internal container path changes to drop the nested prefix. `/health` remains unreachable from the internet, same as before.

Follow-ups (out of scope for this PR):
- Investigate the separate `500 internal error` observed when hitting the route directly via `curl localhost:8001/auth/login/google` — likely Redis or `GOOGLE_CLIENT_ID/SECRET` config; needs container logs
- Update Google Cloud Console authorized redirect URI from `http://api.mogumogu.dev/auth/callback/google` to `https://...`

## Checklist

- [x] CI passes
- [x] No breaking changes to development workflow
- [ ] Tested locally (if applicable) — verified `cargo check` passes; full e2e verification requires deploy + browser flow