### PR TITLE
feat: add request logging middleware for Go service (#76)

### DIFF
--- a/services/go/internal/middleware/logging.go
+++ b/services/go/internal/middleware/logging.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type responseRecorder struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+func (r *responseRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		return xff
+	}
+	if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
+		return xrip
+	}
+	return r.RemoteAddr
+}
+
+func Logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &responseRecorder{ResponseWriter: w}
+		next.ServeHTTP(rec, r)
+		log.Printf("%s %s %s %d %dB %s ip=%s ua=%q",
+			r.Method,
+			r.URL.Path,
+			r.URL.RawQuery,
+			rec.status,
+			rec.bytes,
+			time.Since(start),
+			clientIP(r),
+			r.UserAgent(),
+		)
+	})
+}

--- a/services/go/internal/middleware/logging.go
+++ b/services/go/internal/middleware/logging.go
@@ -43,7 +43,19 @@ func parseIP(s string) (string, bool) {
 	return addr.String(), true
 }
 
-func clientIP(r *http.Request) string {
+func remoteIP(r *http.Request) string {
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if ip, ok := parseIP(host); ok {
+			return ip
+		}
+	}
+	if ip, ok := parseIP(r.RemoteAddr); ok {
+		return ip
+	}
+	return "unknown"
+}
+
+func forwardedIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 		first := xff
 		if idx := strings.IndexByte(first, ','); idx >= 0 {
@@ -56,15 +68,7 @@ func clientIP(r *http.Request) string {
 	if ip, ok := parseIP(r.Header.Get("X-Real-IP")); ok {
 		return ip
 	}
-	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-		if ip, ok := parseIP(host); ok {
-			return ip
-		}
-	}
-	if ip, ok := parseIP(r.RemoteAddr); ok {
-		return ip
-	}
-	return "unknown"
+	return ""
 }
 
 func Logging(next http.Handler) http.Handler {
@@ -75,13 +79,18 @@ func Logging(next http.Handler) http.Handler {
 		if rec.status == 0 {
 			rec.status = http.StatusOK
 		}
-		log.Printf("%s %q %d %dB %s ip=%s ua=%q",
+		fwd := forwardedIP(r)
+		if fwd == "" {
+			fwd = "-"
+		}
+		log.Printf("%s %q %d %dB %s ip=%s fwd=%s ua=%q",
 			r.Method,
 			r.URL.Path,
 			rec.status,
 			rec.bytes,
 			time.Since(start),
-			clientIP(r),
+			remoteIP(r),
+			fwd,
 			r.UserAgent(),
 		)
 	})

--- a/services/go/internal/middleware/logging.go
+++ b/services/go/internal/middleware/logging.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -34,9 +35,14 @@ func (r *responseRecorder) Flush() {
 
 func clientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		return xff
+		if idx := strings.IndexByte(xff, ','); idx >= 0 {
+			xff = xff[:idx]
+		}
+		if ip := strings.TrimSpace(xff); ip != "" {
+			return ip
+		}
 	}
-	if xrip := r.Header.Get("X-Real-IP"); xrip != "" {
+	if xrip := strings.TrimSpace(r.Header.Get("X-Real-IP")); xrip != "" {
 		return xrip
 	}
 	return r.RemoteAddr
@@ -47,10 +53,12 @@ func Logging(next http.Handler) http.Handler {
 		start := time.Now()
 		rec := &responseRecorder{ResponseWriter: w}
 		next.ServeHTTP(rec, r)
-		log.Printf("%s %s %s %d %dB %s ip=%s ua=%q",
+		if rec.status == 0 {
+			rec.status = http.StatusOK
+		}
+		log.Printf("%s %s %d %dB %s ip=%s ua=%q",
 			r.Method,
 			r.URL.Path,
-			r.URL.RawQuery,
 			rec.status,
 			rec.bytes,
 			time.Since(start),

--- a/services/go/internal/middleware/logging.go
+++ b/services/go/internal/middleware/logging.go
@@ -2,7 +2,9 @@ package middleware
 
 import (
 	"log"
+	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 	"time"
 )
@@ -33,19 +35,36 @@ func (r *responseRecorder) Flush() {
 	}
 }
 
+func parseIP(s string) (string, bool) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(s))
+	if err != nil {
+		return "", false
+	}
+	return addr.String(), true
+}
+
 func clientIP(r *http.Request) string {
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if idx := strings.IndexByte(xff, ','); idx >= 0 {
-			xff = xff[:idx]
+		first := xff
+		if idx := strings.IndexByte(first, ','); idx >= 0 {
+			first = first[:idx]
 		}
-		if ip := strings.TrimSpace(xff); ip != "" {
+		if ip, ok := parseIP(first); ok {
 			return ip
 		}
 	}
-	if xrip := strings.TrimSpace(r.Header.Get("X-Real-IP")); xrip != "" {
-		return xrip
+	if ip, ok := parseIP(r.Header.Get("X-Real-IP")); ok {
+		return ip
 	}
-	return r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		if ip, ok := parseIP(host); ok {
+			return ip
+		}
+	}
+	if ip, ok := parseIP(r.RemoteAddr); ok {
+		return ip
+	}
+	return "unknown"
 }
 
 func Logging(next http.Handler) http.Handler {
@@ -56,7 +75,7 @@ func Logging(next http.Handler) http.Handler {
 		if rec.status == 0 {
 			rec.status = http.StatusOK
 		}
-		log.Printf("%s %s %d %dB %s ip=%s ua=%q",
+		log.Printf("%s %q %d %dB %s ip=%s ua=%q",
 			r.Method,
 			r.URL.Path,
 			rec.status,

--- a/services/go/main.go
+++ b/services/go/main.go
@@ -8,6 +8,7 @@ import (
 	"blog-go-api/internal/common"
 	"blog-go-api/internal/config"
 	"blog-go-api/internal/handler"
+	"blog-go-api/internal/middleware"
 	oaiservice "blog-go-api/internal/openai"
 	"blog-go-api/internal/r2"
 	"blog-go-api/internal/redisclient"
@@ -83,5 +84,5 @@ func main() {
 	mux.HandleFunc("GET /hackernews/inspect/db", handler.InspectDBHandler(cfg))
 
 	log.Println("go-api listening on :8003")
-	log.Fatal(http.ListenAndServe(":8003", mux))
+	log.Fatal(http.ListenAndServe(":8003", middleware.Logging(mux)))
 }


### PR DESCRIPTION
## Summary

Add a global logging middleware to the Go service so every inbound HTTP request is logged with method, path, status, latency, and safely-resolved client info.

## Motivation

Closes #76. Previously only a subset of handlers emitted logs, making it hard to confirm whether a request actually reached the Go service or to debug 404s and slow responses. Enabling router-level logging gives full visibility into every endpoint hit.

## Changes

- [x] Add `internal/middleware/logging.go` with a `Logging` middleware that wraps any `http.Handler`
- [x] Capture status code and response size via a `responseRecorder` that also implements `http.Flusher` to preserve streaming handlers; default status to 200 if the handler writes nothing
- [x] Log method, path (escaped via `%q` to prevent log forging), status, bytes, latency, remote IP, forwarded IP, and user-agent
- [x] Resolve `ip` from the trusted TCP `RemoteAddr` (`net.SplitHostPort` + `netip.ParseAddr`); log forwarded headers separately as `fwd=` so they can't spoof the primary IP field
- [x] Exclude query string from logs to avoid leaking sensitive parameters
- [x] Wrap the root `mux` in `main.go` so unmatched routes (404) are captured as well

## Screenshots / Demo

Example log line:

```
2026/04/15 12:00:00 GET "/hackernews/status" 200 123B 1.2ms ip=127.0.0.1 fwd=- ua="curl/8.4.0"
```

## Checklist

- [ ] Tests added/updated
- [x] Documentation updated (if needed)
- [x] No breaking changes (or documented in this PR)
- [x] Follows project coding conventions