### PR TITLE
feat: add HackerNews likes API (#78)

### DIFF
--- a/infra/db/migrations/V0006__create_hackernews_likes_table.sql
+++ b/infra/db/migrations/V0006__create_hackernews_likes_table.sql
@@ -1,0 +1,9 @@
+-- V6: Create hackernews_likes table for per-user HN item likes
+
+CREATE TABLE IF NOT EXISTS public.hackernews_likes (
+    user_id uuid NOT NULL,
+    hn_id bigint NOT NULL,
+    created_at timestamptz DEFAULT now() NOT NULL,
+    CONSTRAINT hackernews_likes_pkey PRIMARY KEY (user_id, hn_id),
+    CONSTRAINT hackernews_likes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE
+);

--- a/services/rust/src/handlers/hackernews.rs
+++ b/services/rust/src/handlers/hackernews.rs
@@ -1,0 +1,46 @@
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde::Serialize;
+
+use crate::auth;
+use crate::config::AppState;
+use crate::stores::hackernews_likes as store;
+use crate::types::ApiError;
+
+#[derive(Serialize)]
+pub struct LikesResponse {
+    pub ids: Vec<i64>,
+}
+
+// GET /hackernews/likes
+pub async fn list_likes(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<LikesResponse>, ApiError> {
+    let user_id = auth::extract_user_id(&state.config, &headers)?;
+    let ids = store::list(&state.db, user_id).await?;
+    Ok(Json(LikesResponse { ids }))
+}
+
+// POST /hackernews/likes/{hn_id}
+pub async fn add_like(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(hn_id): Path<i64>,
+) -> Result<StatusCode, ApiError> {
+    let user_id = auth::extract_user_id(&state.config, &headers)?;
+    store::insert(&state.db, user_id, hn_id).await?;
+    Ok(StatusCode::OK)
+}
+
+// DELETE /hackernews/likes/{hn_id}
+pub async fn remove_like(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(hn_id): Path<i64>,
+) -> Result<StatusCode, ApiError> {
+    let user_id = auth::extract_user_id(&state.config, &headers)?;
+    store::delete(&state.db, user_id, hn_id).await?;
+    Ok(StatusCode::OK)
+}

--- a/services/rust/src/handlers/mod.rs
+++ b/services/rust/src/handlers/mod.rs
@@ -1,4 +1,5 @@
-pub mod posts;
+pub mod hackernews;
 pub mod import;
+pub mod posts;
 pub mod translate;
 pub mod uploads;

--- a/services/rust/src/routes/hackernews.rs
+++ b/services/rust/src/routes/hackernews.rs
@@ -1,0 +1,12 @@
+use axum::routing::{delete, get, post};
+use axum::Router;
+
+use crate::config::AppState;
+use crate::handlers;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/likes", get(handlers::hackernews::list_likes))
+        .route("/likes/{hn_id}", post(handlers::hackernews::add_like))
+        .route("/likes/{hn_id}", delete(handlers::hackernews::remove_like))
+}

--- a/services/rust/src/routes/mod.rs
+++ b/services/rust/src/routes/mod.rs
@@ -1,5 +1,6 @@
-mod posts;
+mod hackernews;
 mod import;
+mod posts;
 mod uploads;
 
 use axum::http::{header, Method};
@@ -41,6 +42,7 @@ pub fn create_router(state: AppState) -> Router {
         .nest("/posts", posts::router())
         .nest("/uploads", uploads::router(upload_limit))
         .nest("/import", import::router())
+        .nest("/hackernews", hackernews::router())
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|req: &axum::http::Request<_>| {

--- a/services/rust/src/stores/hackernews_likes.rs
+++ b/services/rust/src/stores/hackernews_likes.rs
@@ -1,0 +1,51 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::types::ApiError;
+
+pub async fn list(pool: &PgPool, user_id: Uuid) -> Result<Vec<i64>, ApiError> {
+    let rows: Vec<(i64,)> = sqlx::query_as(
+        r#"
+        SELECT hn_id
+        FROM hackernews_likes
+        WHERE user_id = $1
+        ORDER BY created_at DESC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
+pub async fn insert(pool: &PgPool, user_id: Uuid, hn_id: i64) -> Result<(), ApiError> {
+    sqlx::query(
+        r#"
+        INSERT INTO hackernews_likes (user_id, hn_id)
+        VALUES ($1, $2)
+        ON CONFLICT (user_id, hn_id) DO NOTHING
+        "#,
+    )
+    .bind(user_id)
+    .bind(hn_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+pub async fn delete(pool: &PgPool, user_id: Uuid, hn_id: i64) -> Result<(), ApiError> {
+    sqlx::query(
+        r#"
+        DELETE FROM hackernews_likes
+        WHERE user_id = $1 AND hn_id = $2
+        "#,
+    )
+    .bind(user_id)
+    .bind(hn_id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}

--- a/services/rust/src/stores/mod.rs
+++ b/services/rust/src/stores/mod.rs
@@ -1,4 +1,5 @@
 pub mod assets;
 pub mod contents;
+pub mod hackernews_likes;
 pub mod jobs;
 pub mod posts;


### PR DESCRIPTION
## Summary

Adds three authenticated endpoints on the Rust service for per-user HackerNews item likes, backed by a new `hackernews_likes` table.

## Motivation

Closes #78. The Trends UI on the frontend has a star toggle for HackerNews items, but until now there was no backend to persist the state — likes were lost on reload. This PR wires up the storage layer and the minimal CRUD surface the frontend needs.

## Changes

- [x] Add Flyway migration `V0006__create_hackernews_likes_table.sql` with composite PK `(user_id, hn_id)`, `ON DELETE CASCADE` FK to `users(id)`, and no FK to any HN item table (soft reference).
- [x] Add `stores/hackernews_likes.rs` with `list`, `insert` (idempotent via `ON CONFLICT DO NOTHING`), and `delete` SQL.
- [x] Add `handlers/hackernews.rs` with three handlers that extract `user_id` from the existing JWT helper and call the store.
- [x] Add `routes/hackernews.rs` and nest it under `/hackernews` in the main router:
  - `GET /hackernews/likes` → `{ ids: number[] }`
  - `POST /hackernews/likes/{hn_id}` → 200 OK (idempotent)
  - `DELETE /hackernews/likes/{hn_id}` → 200 OK (idempotent)
- [x] Register the new modules in `stores/mod.rs`, `handlers/mod.rs`, `routes/mod.rs`.

### Deviations from the original issue spec

- **`user_id` type**: `uuid`, not `BIGINT`, to match the existing `users.id` column.
- **Auth transport**: `Authorization: Bearer <JWT>`, not cookies. The Rust service already uses Bearer auth (`auth::extract_user_id`); adding a cookie path just for this feature would be inconsistent. The frontend will need to send the Authorization header instead of (or in addition to) `credentials: \"include\"`.

## Screenshots / Demo

N/A — backend only.

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if needed) — OpenAPI spec at `contracts/openapi/specs/hackernews.yaml` does not yet include the new endpoints; will follow up if required.
- [x] No breaking changes (or documented in this PR) — purely additive; new table, new routes, no existing behavior touched.
- [x] Follows project coding conventions — matches the existing handler → store pattern used by `uploads.rs`.

## Test plan

- [ ] Run Flyway migration against a dev database and confirm `hackernews_likes` is created with the expected constraints.
- [ ] With a valid JWT, `GET /hackernews/likes` returns `{ \"ids\": [] }` for a fresh user.
- [ ] `POST /hackernews/likes/12345` twice in a row both return 200 and result in exactly one row (idempotency).
- [ ] `GET /hackernews/likes` now returns `{ \"ids\": [12345] }`.
- [ ] `DELETE /hackernews/likes/12345` returns 200 and the row is gone; calling it again still returns 200.
- [ ] Requests without a valid `Authorization` header return 401.