### PR TITLE
bug: prevent go-api crash from malformed PDF panic (#80)

### DIFF
--- a/infra/docker/compose.prod.yml
+++ b/infra/docker/compose.prod.yml
@@ -21,6 +21,7 @@ services:
     ports:
       - "8001:8001"
     env_file: .env.prod
+    restart: unless-stopped
     depends_on:
       flyway:
         condition: service_completed_successfully
@@ -32,6 +33,7 @@ services:
     ports:
       - "8002:8002"
     env_file: .env.prod
+    restart: unless-stopped
     depends_on:
       flyway:
         condition: service_completed_successfully
@@ -43,6 +45,7 @@ services:
     ports:
       - "8003:8003"
     env_file: .env.prod
+    restart: unless-stopped
     depends_on:
       flyway:
         condition: service_completed_successfully
@@ -54,6 +57,7 @@ services:
     ports:
       - "8004:8004"
     env_file: .env.prod
+    restart: unless-stopped
     depends_on:
       flyway:
         condition: service_completed_successfully

--- a/services/go/internal/scraper/pdf.go
+++ b/services/go/internal/scraper/pdf.go
@@ -53,7 +53,15 @@ func FetchPDFContent(url string) (string, error) {
 	return text, nil
 }
 
-func extractPDFText(path string) (string, error) {
+func extractPDFText(path string) (text string, err error) {
+	// rsc.io/pdf panics on malformed PDF streams instead of returning an error.
+	// Contain it here so one bad PDF fails only this task, not the whole process.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("pdf parse panic: %v", r)
+		}
+	}()
+
 	r, err := pdf.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("open pdf: %w", err)
@@ -75,7 +83,7 @@ func extractPDFText(path string) (string, error) {
 		buf.WriteString("\n\n")
 	}
 
-	text := buf.String()
+	text = buf.String()
 	text = pdfTrailingWs.ReplaceAllString(text, "\n")
 	text = pdfMultiNewline.ReplaceAllString(text, "\n\n")
 	return strings.TrimSpace(text), nil

--- a/services/go/internal/worker/pool.go
+++ b/services/go/internal/worker/pool.go
@@ -1,6 +1,10 @@
 package worker
 
-import "sync"
+import (
+	"log"
+	"runtime/debug"
+	"sync"
+)
 
 // Pool provides bounded concurrency using a semaphore pattern.
 type Pool struct {
@@ -20,6 +24,9 @@ func (p *Pool) Submit(fn func()) {
 	go func() {
 		p.sem <- struct{}{}
 		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[worker] task panic: %v\n%s", r, debug.Stack())
+			}
 			<-p.sem
 			p.wg.Done()
 		}()


### PR DESCRIPTION
## Summary

Stop a single malformed PDF from killing the entire go-api process and leaving the prod container dead until manual intervention.

## Root Cause

Three layers stacked into a full outage:

1. `rsc.io/pdf@v0.1.1` panics on malformed PDF streams instead of returning an error. The library is an unmaintained Russ Cox experimental module.
2. `scraper/pdf.go:extractPDFText` called `p.Content()` with no `recover`, so the upstream panic propagated unchanged.
3. `worker/pool.go:Submit` spawned goroutines with no `recover`, so one task panic tore down the whole Go process. `compose.prod.yml` had no `restart:` policy on api services, so the dead container stayed dead and every subsequent request got 502 from the upstream proxy. One bad URL escalated into a service-wide outage.

Triggered on 260416 by `https://fingfx.thomsonreuters.com/gfx/legaldocs/xmvjyjekkpr/Rakoff%20-%20order%20-%20AI.pdf` appearing on the HN front page. Unrelated to the logging middleware work in `fe13f81..7629e1f`; the latent bomb has been in the code since `b6dedb5`.

## Solution

- `scraper/pdf.go`: add named return + `defer recover()` in `extractPDFText` so `rsc.io/pdf` panics surface as task errors (L2 boundary)
- `worker/pool.go`: add `defer recover()` with stack trace logging in `Submit` goroutines as a defense-in-depth boundary for any future task panic, not just PDF parsing (L3 boundary)
- `compose.prod.yml`: add `restart: unless-stopped` to `auth-api`, `rust-api`, `go-api`, `haskell-api` — covers SIGSEGV / OOM kill / forced exits that `recover` cannot catch (L3 last-resort)

## How to Reproduce (Before Fix)

1. Trigger HN pipeline via `workflow_dispatch` with `date=260416` (or any date whose articles include the Rakoff PDF URL)
2. `POST /hackernews/fetch/260416` returns 200 and enqueues 95 tasks
3. The scraper hits the Rakoff PDF, `rsc.io/pdf` panics, go-api crashes
4. Subsequent `GET /hackernews/fetch/status/260416` returns 502; `curl -sf` exits 22; pipeline step fails
5. Re-running the workflow fails the same way because go-api is still down with no restart policy

## Verification

- `go build ./...` passes on `services/go`
- Manual trigger of the HN pipeline for 260416 after deploy to confirm fetch completes and go-api survives the Rakoff PDF
- Observe `[worker] task panic: ...` log line if any future task panics, without process exit

## Checklist

- [x] Root cause identified and documented
- [ ] Regression test added
- [x] No side effects introduced
- [ ] Tested on affected environments (pending deploy + pipeline rerun)

Closes #80