### PR TITLE
bug: auto-reconnect redis in auth-api to survive idle drops (#83)

### DIFF
--- a/services/auth/Cargo.lock
+++ b/services/auth/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +140,15 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -598,6 +616,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ff"
@@ -1746,10 +1770,13 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e969d1d702793536d5fda739a82b88ad7cbe7d04f8386ee8cd16ad3eff4854a5"
 dependencies = [
+ "arc-swap",
  "arcstr",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "num-bigint",

--- a/services/auth/Cargo.toml
+++ b/services/auth/Cargo.toml
@@ -9,7 +9,7 @@ tokio = { version = "1.49.0", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "tls-rustls", "postgres", "uuid", "chrono"] }
-redis = { version = "1.0.3", features = ["tokio-comp"] }
+redis = { version = "1.0.3", features = ["tokio-comp", "connection-manager"] }
 jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 reqwest = { version = "0.13.2", features = ["json", "form"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/services/auth/src/config/mod.rs
+++ b/services/auth/src/config/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct AppState {
     pub db: sqlx::PgPool,
-    pub redis: redis::aio::MultiplexedConnection,
+    pub redis: redis::aio::ConnectionManager,
     pub config: Arc<AppConfig>,
     pub http: reqwest::Client,
 }

--- a/services/auth/src/main.rs
+++ b/services/auth/src/main.rs
@@ -7,6 +7,7 @@ mod stores;
 mod types;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::net::TcpListener;
 use tokio::signal;
@@ -45,10 +46,14 @@ async fn main() {
 
     let redis_client =
         redis::Client::open(config.redis_url.as_str()).expect("invalid redis URL");
-    let redis: redis::aio::MultiplexedConnection = redis_client
-        .get_multiplexed_async_connection()
+    let redis = redis::aio::ConnectionManager::new(redis_client)
         .await
         .expect("failed to connect to redis");
+
+    tokio::spawn(stores::redis::run_health_loop(
+        redis.clone(),
+        Duration::from_secs(30),
+    ));
 
     let state = config::AppState {
         db,

--- a/services/auth/src/stores/redis.rs
+++ b/services/auth/src/stores/redis.rs
@@ -1,9 +1,42 @@
+use std::time::Duration;
+
 use redis::AsyncCommands;
 use uuid::Uuid;
 
 use crate::types::AuthError;
 
-pub type RedisConn = redis::aio::MultiplexedConnection;
+pub type RedisConn = redis::aio::ConnectionManager;
+
+// Background heartbeat: pings Redis on a fixed interval and logs a single
+// line on each transition between healthy and unreachable. ConnectionManager
+// retries internally, so this loop is observability only.
+pub async fn run_health_loop(mut conn: RedisConn, interval: Duration) {
+    let mut healthy = true;
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        ticker.tick().await;
+        let result = redis::cmd("PING")
+            .query_async::<redis::Value>(&mut conn)
+            .await;
+
+        match result {
+            Ok(_) if !healthy => {
+                tracing::info!("redis connection recovered");
+                healthy = true;
+            }
+            Ok(_) => {}
+            Err(err) if healthy => {
+                tracing::warn!("redis connection lost: {err}");
+                healthy = false;
+            }
+            Err(err) => {
+                tracing::debug!("redis still unreachable: {err}");
+            }
+        }
+    }
+}
 
 // --- Refresh tokens ---
 


### PR DESCRIPTION
## Summary

Fixes a production bug where `blog-auth-api` (Rust) starts returning `redis error: timed out` after some idle time and never recovers until the container is restarted. Replaces the single `MultiplexedConnection` with a `ConnectionManager` (auto-reconnect with backoff) and adds a 30s PING heartbeat that logs disconnect/recovery transitions.

Closes #83

## Root Cause

`services/auth/src/main.rs` opens one `redis::aio::MultiplexedConnection` at startup, stores it in `AppState`, and every handler clones it. `MultiplexedConnection` does **not** auto-reconnect — once the underlying TCP socket is dropped, that connection stays dead forever and all subsequent Redis commands time out.

In production (auth EC2 ↔ Redis EC2, intra-VPC) the auth service has low traffic, so the Redis socket sits idle long enough to be silently dropped by the network path, while the OS TCP keepalive default (~2h) is too long to detect it. After ~11 days of uptime the first OAuth callback after the drop surfaced the failure, and only a container restart cleared it.

## Solution

- Switch `redis::aio::MultiplexedConnection` → `redis::aio::ConnectionManager` in `services/auth/src/main.rs`, `config/mod.rs`, and `stores/redis.rs`. `ConnectionManager` retries with backoff and re-establishes the connection on demand.
- Enable the `connection-manager` feature on the redis crate in `Cargo.toml`.
- Add `run_health_loop` in `stores/redis.rs`: pings Redis every 30s and emits a single log line on each transition between healthy and unreachable (`WARN redis connection lost`, `INFO redis connection recovered`). Reconnection itself is handled by `ConnectionManager`; this loop is observability only.
- Spawn the heartbeat task from `main.rs` after the connection is established.

## How to Reproduce (Before Fix)

1. Start `blog-auth-api` and leave it idle long enough for the path's TCP idle timeout to drop the Redis socket (longer than middleboxes' idle timeout, shorter than OS keepalive).
2. Hit any endpoint that touches Redis (OAuth callback that reads `oauth_state:*`, or the refresh-token flow).
3. The request fails with 500 and logs `redis error: timed out`. Every following Redis call fails the same way until the container is restarted.

## Verification

- `cargo check` passes.
- Local verification plan: run the service against a local docker-compose Redis and confirm the heartbeat stays silent while healthy (transitions only).
- Disconnect simulation: `docker restart` the Redis container and confirm a `WARN redis connection lost` → `INFO redis connection recovered` pair appears in logs, and that OAuth login resumes working without restarting auth-api.
- Staging soak: leave the service idle >24h and confirm the first Redis-touching request still succeeds.

## Checklist

- [ ] Root cause identified and documented
- [ ] Regression test added
- [ ] No side effects introduced
- [ ] Tested on affected environments